### PR TITLE
Minor improvements to the example document

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -91,9 +91,9 @@ Please use sans-serif or non-proportional fonts only for special purposes, such 
 headings or source code text. 
 
 \section*{TITLE AND AUTHORS}
-Your paper’s title, authors and affiliations should run across the full width of the page
+Your paper's title, authors and affiliations should run across the full width of the page
 and centered. The title should be in Arial 18-point bold; use Helvetica if Arial is not
-available. Authors’ names should be in Times Roman 14-point bold, and affiliations in
+available. Authors' names should be in Times Roman 14-point bold, and affiliations in
 Times Roman 12-point (note that AuthorName, AuthorAddress and FirstAuthorEmail as
 well as LastAuthorEmail are defined Styles in this template file).
 
@@ -152,16 +152,16 @@ DiGRA uses a simplified version of the Chicago citation system. In running text 
 endnotes, use \textbackslash cite\{key\} to generate a citation in parenthesis format (Author last names Publication-year).
 To include a page or chapter number, use \textbackslash cite[page]\{key\}, producing
 (Author last names Publication year, Page/Chapter). If the
-authors’ name is mentioned in running text, use \textbackslash textcite instead of \textbackslash cite.
+authors' name is mentioned in running text, use \textbackslash textcite instead of \textbackslash cite.
 This places the authors' name(s) in the text, and only the publication year in parenthesis.
-\textcite[453]{ethics} may or may not think this is a good idea, but it doesn’t matter since
+\textcite[453]{ethics} may or may not think this is a good idea, but it doesn't matter since
 this sentence is only included as an example. If a reference has more than two authors
 \cite{schwartz.1995}, use the name of the first author ``et al.'' in the reference. 
 
 Organize the bibliography alphabetically by last name of the first author. See the
 bibliography towards the end of the template for example formatting of references.
 \subsection*{Game references}
-For games, set the game’s name in italics with initial capitals. On first occurrence in the
+For games, set the game's name in italics with initial capitals. On first occurrence in the
 text, include the developer and publication year in parenthesis, e.g. \textit{World of Warcraft}
 \nocite{WoW}. There doesn't seem to be a clear way to cite a game in LaTeX so it is recommended to use the misc type in the bibliography (see the attached bib file for an example) and to do something like $\backslash$textit\{World of Warcraft\} $\backslash$nocite\{WoW\}.  Depending on the use of the game in the context of the article, you may
 also choose to refer to the principal designer(s), creator(s), and so on. Follow this format
@@ -190,7 +190,7 @@ has read a particular article).
 translate.
 \item Use unambiguous forms for culturally localized concepts, such as times, dates,
 currencies and numbers (e.g., ``1-5- 97'' or ``5/1/97'' may mean 5 January or 1
-May, and ``seven o’clock'' may mean 7:00 am or 19:00). For small currencies,
+May, and ``seven o'clock'' may mean 7:00 am or 19:00). For small currencies,
 indicate equivalences in Euro or Dollar – e.g., ``Participants were paid 10,000 lire,
 or roughly \$5.''
 \item Be careful with the use of gender-specific pronouns (he, she) and other gendered
@@ -204,7 +204,7 @@ concepts and names. Make sure to include latin transcriptions if this is necessa
 \section*{PRODUCING AND TESTING PDF FILES}
 We recommend that you produce a PDF version of your submission well before the final
 deadline. Besides making sure that you are able to produce a PDF, you will need to
-check that (a) the length of the file remains within the submission category’s page limit, if
+check that (a) the length of the file remains within the submission category's page limit, if
 applicable, (b) the PDF file size is 4 megabytes or less, and (c) the file can be read and
 printed using Adobe Acrobat Reader.
 
@@ -223,7 +223,7 @@ remove part or all of the Acknowledgments text. Further suppression of identity 
 body of the paper and references is left to the authors' discretion. For more details, see the
 submission guidelines and checklist for your submission category.
 \section*{CONCLUSION}
-It is important that you write for the DiGRA audience. Please read previous years’
+It is important that you write for the DiGRA audience. Please read previous years'
 Proceedings (available from the DiGRA library, http://www.digra.org/dl) to understand
 the writing style and conventions that successful authors have used. It is particularly
 important that you state clearly what you have done, not merely what you plan to do, and

--- a/main.tex
+++ b/main.tex
@@ -117,8 +117,8 @@ width of 14 cm (5.5 in.). If possible, the Figure should appear on the same page
 it is first referenced.
 
 Captions should be Times New Roman 11-point bold. They should be numbered (e.g.,
-“Table 1” or “Figure 2”), centered and placed beneath the figure or table. Please note that
-the words “Figure” and “Table” should be spelled out (e.g., “Figure” rather than “Fig.”)
+``Table 1'' or ``Figure 2''), centered and placed beneath the figure or table. Please note that
+the words ``Figure'' and ``Table'' should be spelled out (e.g., ``Figure'' rather than ``Fig.'')
 wherever they occur.  To do this in LaTeX use $\backslash$ caption*\{\textbf{Table 1}\} instead of  $\backslash$ caption\{\}, i.e. you will need to suppress the normal numbering and do it yourself.
 
 Papers and notes may use color figures, which are included in the page limit. The paper
@@ -154,7 +154,7 @@ endnotes, use a verbose parenthesis format (Author last names Publication-year) 
 authors’ name is mentioned in running text, use only the publication year in parenthesis.
  Anderson (1992, 453) \nocite{ethics} may or may not think this is a good idea, but it doesn’t matter since
 this sentence is only included as an example. If a reference has more than two authors
-\cite{schwartz.1995}, use the name of the first author “et al.” in the reference. 
+\cite{schwartz.1995}, use the name of the first author ``et al.'' in the reference. 
 
 Organize the bibliography alphabetically by last name of the first author. See the
 bibliography towards the end of the template for example formatting of references.
@@ -176,21 +176,21 @@ the following:
 \item Write in a straightforward style. Try to avoid long or complex sentence
 structures.
 \item Briefly define or explain all technical terms that may be unfamiliar to readers.
-\item Explain all acronyms the first time they are used in your text – e.g., “Alternate
-Reality Game (ARG)”.
+\item Explain all acronyms the first time they are used in your text – e.g., ``Alternate
+Reality Game (ARG)''.
 \item Explain local references (e.g., not everyone knows that a child in the first grade
 of school in the US is 6-7 years old).
 
-\item Explain “insider” comments. Ensure that your whole audience understands any
+\item Explain ``insider'' comments. Ensure that your whole audience understands any
 reference whose meaning you do not describe (and do not assume that everyone
 has read a particular article).
 \item Avoid or explain colloquial language and puns. Humor and irony are difficult to
 translate.
 \item Use unambiguous forms for culturally localized concepts, such as times, dates,
-currencies and numbers (e.g., “1-5- 97” or “5/1/97” may mean 5 January or 1
-May, and “seven o’clock” may mean 7:00 am or 19:00). For small currencies,
-indicate equivalences in Euro or Dollar – e.g., “Participants were paid 10,000 lire,
-or roughly \$5.”
+currencies and numbers (e.g., ``1-5- 97'' or ``5/1/97'' may mean 5 January or 1
+May, and ``seven o’clock'' may mean 7:00 am or 19:00). For small currencies,
+indicate equivalences in Euro or Dollar – e.g., ``Participants were paid 10,000 lire,
+or roughly \$5.''
 \item Be careful with the use of gender-specific pronouns (he, she) and other gendered
 words (chairman, manpower, man-months). Use inclusive language that is
 gender-neutral (e.g., she or he, they, s/he, chair, staff, staff-hours, person-years).

--- a/main.tex
+++ b/main.tex
@@ -46,7 +46,7 @@ for the worldwide DiGRA readership.
 \section*{Keywords}
 keyword, keyword, keyword, keyword
 
-\subsection*{INTRODUCTION}
+\section*{INTRODUCTION}
 
 Place your text here. Your text goes here. This format is to be used for submissions that
 are published in the electronic conference proceedings for DiGRA conferences\endnote{ The format was developed for DiGRA 2011, modified slightly for DiGRA Nordic 2012 and FDG/DiGRA 2016, and may change for future conferences. A slightly different format may apply for the forthcoming DiGRA journal.}

--- a/main.tex
+++ b/main.tex
@@ -149,10 +149,12 @@ Endnotes are also in 12 point Times New Roman.
 
 \subsection*{Citations and References}
 DiGRA uses a simplified version of the Chicago citation system. In running text and
-endnotes, use a verbose parenthesis format (Author last names Publication-year) or
-(Author last names Publication year, Page/Chapter) to indicate your reference. If the
-authors’ name is mentioned in running text, use only the publication year in parenthesis.
- Anderson (1992, 453) \nocite{ethics} may or may not think this is a good idea, but it doesn’t matter since
+endnotes, use \textbackslash cite\{key\} to generate a citation in parenthesis format (Author last names Publication-year).
+To include a page or chapter number, use \textbackslash cite[page]\{key\}, producing
+(Author last names Publication year, Page/Chapter). If the
+authors’ name is mentioned in running text, use \textbackslash textcite instead of \textbackslash cite.
+This places the authors' name(s) in the text, and only the publication year in parenthesis.
+\textcite[453]{ethics} may or may not think this is a good idea, but it doesn’t matter since
 this sentence is only included as an example. If a reference has more than two authors
 \cite{schwartz.1995}, use the name of the first author ``et al.'' in the reference. 
 

--- a/main.tex
+++ b/main.tex
@@ -70,18 +70,18 @@ ways.
 Section headings should be typeset in 12-point Arial bold. Section headers should be set
 in all capitals. Leave space corresponding to approximately one line above each heading.
 
-In LaTeX to avoid numbering of sections you have to use $\backslash$section*\{\} instead of $\backslash$section\{\}
+In LaTeX to avoid numbering of sections you have to use \textbackslash section*\{\} instead of \textbackslash section\{\}
 \subsection*{Subsections}
 Headings of subsections should be in 12-point Arial bold with initial letters capitalized.
 (Note: For sub-sections, a word like the or of is not capitalized unless it is the first word
 of the heading.)
 
-In LaTeX to avoid numbering of sections you have to use $\backslash$subsection*\{\} instead of $\backslash$subsection\{\}.
+In LaTeX to avoid numbering of sections you have to use \textbackslash subsection*\{\} instead of \textbackslash subsection\{\}.
 \subsubsection*{Sub-subsections}
 Headings of sub-subsections should be in 12-point Arial italic, with the first letter
 capitalized. Do not use more than three levels of headings. 
 
-In LaTeX to avoid numbering of sections you have to use $\backslash$subsubsection*\{\} instead of $\backslash$subsubsection\{\}
+In LaTeX to avoid numbering of sections you have to use \textbackslash subsubsection*\{\} instead of \textbackslash subsubsection\{\}
 \section*{BODY TEXT}
 For body text, please use a 11-point Times Roman font or, if this is unavailable, another
 proportional font with serifs, as close as possible in appearance to Times Roman 11-
@@ -119,7 +119,7 @@ it is first referenced.
 Captions should be Times New Roman 11-point bold. They should be numbered (e.g.,
 ``Table 1'' or ``Figure 2''), centered and placed beneath the figure or table. Please note that
 the words ``Figure'' and ``Table'' should be spelled out (e.g., ``Figure'' rather than ``Fig.'')
-wherever they occur.  To do this in LaTeX use $\backslash$ caption*\{\textbf{Table 1}\} instead of  $\backslash$ caption\{\}, i.e. you will need to suppress the normal numbering and do it yourself.
+wherever they occur.  To do this in LaTeX use \textbackslash  caption*\{\textbf{Table 1}\} instead of  \textbackslash  caption\{\}, i.e. you will need to suppress the normal numbering and do it yourself.
 
 Papers and notes may use color figures, which are included in the page limit. The paper
 may be accompanied by various media files, such as videos, sound clips, and even
@@ -163,7 +163,7 @@ bibliography towards the end of the template for example formatting of reference
 \subsection*{Game references}
 For games, set the game's name in italics with initial capitals. On first occurrence in the
 text, include the developer and publication year in parenthesis, e.g. \textit{World of Warcraft}
-\nocite{WoW}. There doesn't seem to be a clear way to cite a game in LaTeX so it is recommended to use the misc type in the bibliography (see the attached bib file for an example) and to do something like $\backslash$textit\{World of Warcraft\} $\backslash$nocite\{WoW\}.  Depending on the use of the game in the context of the article, you may
+\nocite{WoW}. There doesn't seem to be a clear way to cite a game in LaTeX so it is recommended to use the misc type in the bibliography (see the attached bib file for an example) and to do something like \textbackslash textit\{World of Warcraft\} \textbackslash nocite\{WoW\}.  Depending on the use of the game in the context of the article, you may
 also choose to refer to the principal designer(s), creator(s), and so on. Follow this format
 as closely as possible:
 Developer. (Year). Title. [Platform, Version], Publisher, Release City/State and Country:


### PR DESCRIPTION
I realize it's past the submission deadline now, but in case it's useful for the future, I've made some miscellaneous improvements to the example document. The main substantive change is suggesting \textcite for in-text citations, instead of the hack of writing the author name manually and then sticking in a \nocite. The other changes are small formatting things (getting rid of raw curly quotes, and better formatting escaped backslashes).
